### PR TITLE
Move request headers into 'ApiOptions'

### DIFF
--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -9,13 +9,14 @@ export const setGlobalApiBase = (apiBase: string) =>
 export type ApiOptions = {
   fetch?: typeof fetch;
   apiBase?: string;
+  headers?: Record<string, string>;
 };
 
 export const requestPlain = (
   method: Method,
   url: string,
   body?: unknown,
-  options?: ApiOptions & { headers?: Record<string, string> }
+  options?: ApiOptions
 ): {
   data: Promise<string>;
   cancel: (reason?: string) => void;


### PR DESCRIPTION
Some api endpoints requires the caller to be able to control the request headers, e.g. when authenticating with a `Bearer` token. This PR moves the headers into the `ApiOptions` type so they can be set when requesting an api resource.