### PR TITLE
Update openapi spec from 3.0.x to 3.1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,6 @@ dependencies = [
  "heck",
  "indent_write",
  "itertools",
- "openapiv3",
  "pluralizer",
  "reqwest",
  "salsa-2022",
@@ -21,6 +20,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "utoipa",
 ]
 
 [[package]]
@@ -839,17 +839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openapiv3"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e56d5c441965b6425165b7e3223cc933ca469834f4a8b4786817a1f9dc4f13"
-dependencies = [
- "indexmap 2.0.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1472,29 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "utoipa"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514a48569e4e21c86d0b84b5612b5e73c0b2cf09db63260134ba426d4e8ea714"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5629efe65599d0ccd5d493688cbf6e03aa7c1da07fe59ff97cf5977ed0637f66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ color-eyre = "0.6.2"
 heck = "0.4.1"
 indent_write = "2.2.0"
 itertools = "0.11.0"
-openapiv3 = "1.0.3"
+utoipa = { version = "5.2.0", features = ["debug"] }
 pluralizer = "0.4.0"
 reqwest = { version = "0.11.20", features = ["blocking", "json"] }
 salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use abeye::{generate_ts, Config, Database, InputApi};
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::Result;
-use openapiv3 as oapi;
 use tracing_subscriber::{filter::LevelFilter, prelude::*, EnvFilter};
+use utoipa::openapi as oapi;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -44,7 +44,7 @@ fn run() -> Result<()> {
             output,
             api_prefix,
         } => {
-            let api: oapi::OpenAPI = match source {
+            let api: oapi::OpenApi = match source {
                 Some(s) if s.starts_with("http://") || s.starts_with("https://") => {
                     tracing::info!(url=?s, "fetching schema");
                     reqwest::blocking::get(s)?.json()?

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -24,20 +24,9 @@ pub fn generate_ts(db: &dyn crate::Db, api: InputApi) -> String {
         .paths
         .paths
         .iter()
-        // .filter_map(|(path, item)| {
-        //     if item.parameters.is_none() || item.parameters.as_ref().unwrap().is_empty() {
-        //         dbg!(item.parameters.is_some());
-        //         return None;
-        //     }
-        //     Some((path, item))
-        // })
         .flat_map(|(path, item)| {
             let span = tracing::debug_span!("endpoint", path);
             let _enter = span.enter();
-
-            // if item.parameters.is_none() || item.parameters.as_ref().unwrap().is_empty() {
-            //     unreachable!()
-            // }
 
             let gen_op = |method: &'static str, op: &Option<oapi::path::Operation>| {
                 op.as_ref()


### PR DESCRIPTION
3.1 is unfortunately not backwards compatible with 3.0, so we have to change the openapi type from 'openapiv3', which only supports 3.0, to the one used internally in utoipa. This of course results in a big internal change in abeye, but I think the functionality is roughly the same. The generated bindings at least fully type checks in stract.